### PR TITLE
removes duplicated Left keybinding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,6 @@ function App() {
   //prettier-ignore
   {
   useKeyDown(() => handleInput(shiftBlock(gameState, "L")), ["a","ArrowLeft"]);
-  useKeyDown(() => handleInput(shiftBlock(gameState, "L")), ["a","ArrowLeft"]);
   useKeyDown(() => handleInput(shiftBlock(gameState, "R")), ["d","ArrowRight"]);
   useKeyDown(() => handleInput(shiftBlock(gameState, "D")), ["s","ArrowDown"]);
   useKeyDown(() => handleInput(hardDropBlock(gameState)), [" "]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1112de6bf06aefe018ff89ed2e99d0d568353061  | 
|--------|--------|

### Summary:
Removed duplicated keybinding for 'Left' arrow key in `src/App.tsx` to ensure single binding to `shiftBlock` function with 'L' direction.

**Key points**:
- Removed duplicated keybinding for 'Left' arrow key in `src/App.tsx`.
- Ensured 'Left' arrow key is only bound once to `shiftBlock` function with 'L' direction.
- Modified `useKeyDown` call in `App` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->