### PR TITLE
reverts block grace counter to only increment when on ground

### DIFF
--- a/src/Tetris.ts
+++ b/src/Tetris.ts
@@ -201,8 +201,8 @@ export const tickGravity = (game: Game): Game => {
   const newGame = clearThenCollapseRows(game);
   if (newGame.fallingBlock === null) return newGame;
   const nextBlock = shiftedBlock(newGame.fallingBlock, "D");
-  //if we are on the ground OR have been (since thats the only way the counter could have gotten incremented...)
-  if (blockOnGround(game) || game.groundGracePeriod.counter > 0)
+  //if we are on the ground...)
+  if (blockOnGround(game))
     //prevent settling if the grace period bool is true and hasnt been reset more than the MAX COUNT number of times
     return game.groundGracePeriod.protected &&
       game.groundGracePeriod.counter < CONFIG.MAX_GRACE_COUNT


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fda7a2714b39d6f1b7400dcbf5cdec0261fa6d62  | 
|--------|--------|

### Summary:
Reverted ground grace counter increment condition in `tickGravity` to only when the block is on the ground.

**Key points**:
- Reverted ground grace counter increment condition in `tickGravity` function in `src/Tetris.ts`.
- Now increments only when the block is on the ground.
- Removed condition checking if `groundGracePeriod.counter > 0`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->