### PR TITLE
Color style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import ThemeSong from "./assets/ThemeSong.mp3";
 import useKeysPressed from "./hooks/useKeysPressed";
 import { CONFIG, InputCategory } from "./TetrisConfig";
+import BoardCell from "./components/BoardCell";
 const music = new Audio(ThemeSong);
 const startMusic = () => {
   music.loop = true;
@@ -38,12 +39,14 @@ const keyBindings: KeyBinding[] = [
   { key: "ArrowUp", type: "rotate",callback: (prevGameState) => rotateBlock(prevGameState, "CW")},
   { key: "ArrowDown", type:"shift", callback: (prevGameState) => rotateBlock(prevGameState, "CCW")},
 ];
+const cellBorderStyles = ["outset", "none"];
 
 function App() {
   const [gameClock, setGameClock] = useState(0);
   const [gameState, setGameState] = useState(gameInit());
   const gameStateRef = useRef(gameState);
   const [unMuted, setMuted] = useState<boolean | null>(null);
+  const [cellBorderStyleIndex, setCellBorderStyle] = useState(0);
   const keysPressed = useKeysPressed(keyBindings.map(binding => binding.key));
   const keysPressedRef = useRef(keysPressed);
   //up to date ref to pass to our interval callbacks
@@ -82,7 +85,10 @@ function App() {
       }
     });
   };
-
+  const toggleCellBorderStyle = () => {
+    const newIndex = (cellBorderStyleIndex + 1) % cellBorderStyles.length;
+    setCellBorderStyle(newIndex);
+  };
   //Increment game clock every tickInterval ms
   useEffect(() => {
     const tickTimeout = setTimeout(
@@ -113,7 +119,10 @@ function App() {
     <>
       <div className="flex justify-center">
         <div className="m-2 flex flex-col items-center gap-2 w-fit">
-          <BoardDisplay board={boardWithFallingBlock(gameState)} />
+          <BoardDisplay
+            board={boardWithFallingBlock(gameState)}
+            cellBorderStyle={cellBorderStyles[cellBorderStyleIndex]}
+          />
           <div className="flex justify-between w-full ">
             <div className="flex justify-start basis-full">
               <div className="text-5xl font-mono text-green-500">
@@ -128,13 +137,22 @@ function App() {
                 Start
               </button>
             </div>
-            <div className="flex justify-end basis-full">
-              <div onClick={e => handleSoundClick(e)}>
-                {unMuted ? (
-                  <Volume2 className="w-10 h-10" color="#ffffff" />
-                ) : (
-                  <VolumeX className="w-10 h-10" color="#ffffff" />
-                )}
+            <div className="flex justify-end items-start basis-full">
+              <div className="flex items-center gap-2">
+                <div className="w-8 h-8" onClick={toggleCellBorderStyle}>
+                  <BoardCell
+                    cellValue={{ color: [0, 255, 255], type: "block" }}
+                    cellBorderStyle={cellBorderStyles[cellBorderStyleIndex]}
+                    position={[0, 0]}
+                  />
+                </div>
+                <div onClick={e => handleSoundClick(e)}>
+                  {unMuted ? (
+                    <Volume2 className="w-10 h-10" color="#ffffff" />
+                  ) : (
+                    <VolumeX className="w-10 h-10" color="#ffffff" />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -3,12 +3,13 @@ import { Board } from "../Tetris";
 
 type BoardDisplayProps = {
   board: Board;
+  cellBorderStyle: string;
 };
 
 const keyFromPosition = (a: number, b: number) =>
   a.toString().padStart(2, "0") + b.toString().padStart(2, "0");
 
-const BoardDisplay = ({ board }: BoardDisplayProps) => {
+const BoardDisplay = ({ board, cellBorderStyle }: BoardDisplayProps) => {
   const aspectRatio = board[0].length / board.length;
   const dimensions: React.CSSProperties = {
     aspectRatio: aspectRatio
@@ -21,6 +22,7 @@ const BoardDisplay = ({ board }: BoardDisplayProps) => {
             <BoardCell
               position={[row, col]}
               cellValue={cell}
+              cellBorderStyle={cellBorderStyle}
               key={keyFromPosition(row, col)}
             />
           ))}

--- a/src/components/BoardCell.tsx
+++ b/src/components/BoardCell.tsx
@@ -5,8 +5,13 @@ import { Color } from "../TetrisConfig";
 interface BoardCellProps {
   cellValue: Cell;
   position: [number, number];
+  cellBorderStyle: string;
 }
-const BoardCell = ({ cellValue, position }: BoardCellProps) => {
+const BoardCell = ({
+  cellValue,
+  position,
+  cellBorderStyle
+}: BoardCellProps) => {
   const [row, col] = position;
   const blankCellBackground = ((row % 2) + (col % 2)) % 2 ? 22 : 6;
   //we use the color of a cell unless it is empty or shadow, in which case we use the blank cell background checkerboard pattern
@@ -43,10 +48,11 @@ const BoardCell = ({ cellValue, position }: BoardCellProps) => {
       case "shadow":
         return "solid";
       case "block":
+        return cellBorderStyle;
       case "wall":
         return "outset";
     }
-  }, [cellValue]);
+  }, [cellValue, cellBorderStyle]);
   const borderWidth = useMemo(() => {
     switch (cellValue.type) {
       case "empty":
@@ -67,7 +73,7 @@ const BoardCell = ({ cellValue, position }: BoardCellProps) => {
     borderColor: borderColor,
     flex: "1 1 16px"
   };
-  return <div style={cellDynamicStyles}></div>;
+  return <div className="w-full h-full" style={cellDynamicStyles}></div>;
 };
 
 export default BoardCell;

--- a/src/components/BoardCell.tsx
+++ b/src/components/BoardCell.tsx
@@ -20,7 +20,7 @@ const BoardCell = ({
       cellValue.type === "empty"
         ? [blankCellBackground, blankCellBackground, blankCellBackground]
         : cellValue.color,
-    [cellValue, blankCellBackground]
+    [cellValue.color[0], cellValue.color[1], cellValue.color[2], cellValue.type]
   );
   const backgroundColor = useMemo(() => {
     switch (cellValue.type) {
@@ -33,13 +33,13 @@ const BoardCell = ({
       default:
         return `rgba(${r}, ${g}, ${b})`;
     }
-  }, [cellValue]);
+  }, [cellValue.type, r, g, b]);
   const borderColor = useMemo(
     () =>
       `rgb(${Math.floor(0.8 * r)}, ${Math.floor(0.8 * g)}, ${Math.floor(
         0.8 * b
       )})`,
-    [cellValue, r, g, b]
+    [r, g, b]
   );
   const borderStyle = useMemo(() => {
     switch (cellValue.type) {
@@ -52,7 +52,7 @@ const BoardCell = ({
       case "wall":
         return "outset";
     }
-  }, [cellValue, cellBorderStyle]);
+  }, [cellValue.type, cellBorderStyle]);
   const borderWidth = useMemo(() => {
     switch (cellValue.type) {
       case "empty":
@@ -63,7 +63,7 @@ const BoardCell = ({
       case "wall":
         return 6;
     }
-  }, [cellValue]);
+  }, [cellValue.type]);
 
   const cellDynamicStyles: React.CSSProperties = {
     background: backgroundColor,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bbf88de6aa8c372663a96331e0d64de631a04827  | 
|--------|--------|

### Summary:
Added functionality to toggle the border style of Tetris board cells, updating `App`, `BoardDisplay`, and `BoardCell` components accordingly.

**Key points**:
- Added `cellBorderStyleIndex` state in `src/App.tsx` to manage border styles.
- Introduced `toggleCellBorderStyle` function in `src/App.tsx` to switch between border styles.
- Passed `cellBorderStyle` prop from `BoardDisplay` to `BoardCell` in `src/components/Board.tsx`.
- Updated `BoardCell` component in `src/components/BoardCell.tsx` to apply the selected border style for 'block' type cells.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->